### PR TITLE
fast-and-dirty json signing using the signhelper of camlistore

### DIFF
--- a/camlistore/__init__.py
+++ b/camlistore/__init__.py
@@ -9,3 +9,7 @@ from camlistore.connection import (
 from camlistore.blobclient import (
     Blob,
 )
+
+from camlistore.schema import (
+    Schema,
+)

--- a/camlistore/exceptions.py
+++ b/camlistore/exceptions.py
@@ -47,3 +47,9 @@ class HashMismatchError(Exception):
     value.
     """
     pass
+
+class MissingFieldError(Exception):
+    """
+    There was a missing JSON field in a schema blob
+    """
+    pass

--- a/camlistore/jsonsign.py
+++ b/camlistore/jsonsign.py
@@ -1,0 +1,41 @@
+import sys
+
+class JsonSign(object):
+    """
+    Use the Sign Helper to sign a Json blob. Eventually, also support 
+    signing JSON using PyCrypto or something locally
+
+    Callers should not instantiate this class directly. Instead, call
+    :py:func:`camlistore.connect` to obtain a
+    :py:class:`camlistore.Connection`
+    object and access :py:attr:`camlistore.Connection.jsonsign`.
+    """
+
+    def __init__(self, http_session, sign_handler, public_key):
+        self.http_session = http_session
+        self.sign_handler = sign_handler
+        self.public_key = public_key
+
+
+    def sign_schema(self, schemablob):
+        """
+        Upload a schema blob to camlistore and get it signed.
+        """
+        import hashlib
+
+        upload_url = self.sign_handler
+        if 'camliSigner' not in schemablob.parsed_json:
+            schemablob.add_attribute("camliSigner", self.public_key)
+        encoded = {u'json': schemablob.blob.data} 
+        resp = self.http_session.post(upload_url, data=encoded)
+        if resp.status_code != 200:
+            from camlistore.exceptions import ServerError
+            raise ServerError(
+                "Failed to sign blob: got %i %s" % (
+                    resp.status_code,
+                    resp.reason,
+                )
+            )
+
+        return resp.text
+

--- a/camlistore/schema.py
+++ b/camlistore/schema.py
@@ -1,0 +1,53 @@
+import json
+
+class Schema(object):
+    """
+    Represents a schema blob.
+
+    Schema blobs are JSON objects with at least two attributes always set: 
+    camliVersion, which is always 1, and camliType, which tells you the 
+    type of metadata the blob contains.
+   
+    See http://camlistore.org/docs/schema for more 
+    """
+    def parsed_json_helper(self):
+        # Just toss a TypeError here if passed something not JSON
+        self._parsed_json = json.loads(self.blob.data)
+        if type(self._parsed_json) is not dict or \
+            'camliVersion' not in self._parsed_json or \
+            'camliType' not in self._parsed_json or \
+            self._parsed_json['camliVersion'] != 1:
+            from camlistore.exceptions import MissingFieldError
+            raise MissingFieldError
+             
+
+    def __init__(self, blob):
+        self.blob = blob 
+        self.parsed_json_helper()
+
+    #
+    # this needs to be actually thought out - if a schema element changes, the 
+    # underlying  blob has to change, too. I'm not sure what the right interface 
+    # into a schema should be - twiddling with the JSON directly, or treating it 
+    # always as a dictionary that's only serialized to JSON at the last possible
+    # minute. 
+    #
+    # my original thinking was some magic watching ala the camlistore.Blob, 
+    # so if the parsed json changes, update the string, 
+    # or if the string changes, reparse the dictionary.
+    # at the moment, the only thing I want this for is to add camliSigner
+    # For now, just json.dumps back to the string, and assume no one
+    # changes the blob.data on us
+    #
+    #
+    def add_attribute(self, k, v):
+        self._parsed_json[k]=v
+        self.blob.data = json.dumps(self.parsed_json)
+        self.parsed_json_helper()
+
+    @property
+    def parsed_json(self):
+         if self._parsed_json is None:
+            self.parsed_json_helper()
+         return self._parsed_json
+


### PR DESCRIPTION
I don't actually think you'll want to merge this, but a big missing piece of your camlistore client is the ability to create signed schema blobs for permanodes, claims, and the like. 

This is a dirt-simple addition that creates "schema" blobs and passes them on to the signing helper to get signed. It does some rudimentary validation that the schema blob is in fact a camlistore schema, and asks the camli online configuration for the signing key to use. I started a bit down the path to look in the users config file to find the private key to do the signing locally, with the plan of using something like PyCrypto or some other library.

I'm mostly just putting this out there to see if you had some thoughts about how you wanted to support a richer interface beyond just blobs, and again, I don't expect this to get merged, it's just a conversation starter.

Thanks!
